### PR TITLE
chore: 자바 툴체인 삭제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,12 +8,6 @@ group = 'com.tidy'
 version = '0.0.1-SNAPSHOT'
 description = 'Tidy service project'
 
-java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
-}
-
 configurations {
 	compileOnly {
 		extendsFrom annotationProcessor

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,7 +12,7 @@ spring.servlet.multipart.max-request-size=50MB
 
 # 기본 프로필 (서버용)
 # 로컬에서 실행할 때는 IDE 환경변수로 local 지정
-spring.profiles.active=dev
+spring.profiles.active=local
 
 # 세션 공통 설정
 server.servlet.session.timeout=30m


### PR DESCRIPTION
AWS 서버에서 자바 툴체인 설정때문에 서버에 깔린 JDK 인식을 못해서 툴체인 설정을 삭제했습니다.

애플리케이션 서버를 돌릴 때는 컴퓨터에 java17 설치가 되어있어야합니다