### PR TITLE
fix: 슬라이드 조회에 카운트 추가

### DIFF
--- a/src/main/java/com/tidy/tidy/api/PresentationController.java
+++ b/src/main/java/com/tidy/tidy/api/PresentationController.java
@@ -1,12 +1,10 @@
 package com.tidy.tidy.api;
 
+import com.tidy.tidy.api.dto.SlideListResponse;
 import com.tidy.tidy.domain.slide.SlideService;
-import com.tidy.tidy.api.dto.SlideResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,7 +14,7 @@ public class PresentationController {
     private final SlideService slideService;
 
     @GetMapping("/{presentationId}/slides")
-    public ResponseEntity<List<SlideResponse>> getSlides(
+    public ResponseEntity<SlideListResponse> getSlides(
             @PathVariable Long presentationId) {
 
         return ResponseEntity.ok(slideService.getSlides(presentationId));

--- a/src/main/java/com/tidy/tidy/api/dto/SlideListResponse.java
+++ b/src/main/java/com/tidy/tidy/api/dto/SlideListResponse.java
@@ -1,0 +1,13 @@
+package com.tidy.tidy.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class SlideListResponse {
+    private int slideCount;
+    private List<SlideResponse> slides;
+}

--- a/src/main/java/com/tidy/tidy/domain/slide/SlideService.java
+++ b/src/main/java/com/tidy/tidy/domain/slide/SlideService.java
@@ -1,5 +1,6 @@
 package com.tidy.tidy.domain.slide;
 
+import com.tidy.tidy.api.dto.SlideListResponse;
 import com.tidy.tidy.domain.presentation.Presentation;
 import com.tidy.tidy.domain.presentation.PresentationRepository;
 import com.tidy.tidy.infrastructure.python.PythonApiClient;
@@ -44,7 +45,7 @@ public class SlideService {
         slideRepository.deleteByPresentation(p);
 
         // 4) 새 슬라이드 저장
-        int index = 1;
+        int index = 0;
         for (String key : keys) {
             Slide sl = new Slide(index, key, p); // thumbnailUrl ← 이제 S3 key
             slideRepository.save(sl);
@@ -57,16 +58,19 @@ public class SlideService {
     }
 
     @Transactional(readOnly = true)
-    public List<SlideResponse> getSlides(Long presentationId) {
+    public SlideListResponse getSlides(Long presentationId) {
         Presentation p = presentationRepository.findById(presentationId)
                 .orElseThrow(() -> new IllegalArgumentException("Presentation not found"));
 
-        return slideRepository.findAllByPresentationOrderBySlideIndexAsc(p)
+        List<SlideResponse> slides = slideRepository.findAllByPresentationOrderBySlideIndexAsc(p)
                 .stream()
                 .map(s -> new SlideResponse(
                         s.getId(),
                         s.getSlideIndex(),
-                        s.getThumbnailUrl()  // 이제 S3 key 그대로 반환
-                )).toList();
+                        s.getThumbnailUrl()
+                ))
+                .toList();
+
+        return new SlideListResponse(slides.size(), slides);
     }
 }


### PR DESCRIPTION
## 🚩 관련 이슈
슬라이드 목록 조회 api에 카운트도 같이 넘겨야 함

## 📢 작업 내용
- SlideResponse 구조는 남겨두고 SlideListResponse DTO 새로 만들어서 카운트를 같이 넘김
- 추가로 기존에 S3에 이미지가 저장될때 인덱스(0부터 시작)가 아니라 순서(1부터 시작) 기준으로 저장됐었는데 인덱스로 통일해서 0부터 저장되도록 바꿈

## 📸 스크린샷

## ⚙️ 기타사항

