### PR TITLE
hotfix: aws region 문제 해결

### DIFF
--- a/src/main/java/com/tidy/tidy/infrastructure/storage/S3StorageService.java
+++ b/src/main/java/com/tidy/tidy/infrastructure/storage/S3StorageService.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -14,20 +15,21 @@ import java.net.URL;
 import java.util.Date;
 
 @Service
+@Slf4j
 @Profile({"local", "dev"})   // 둘 다 S3 사용
 @RequiredArgsConstructor
 public class S3StorageService implements StorageService {
 
     private final AmazonS3 amazonS3;
 
-    @Value("${cloud.aws.s3.bucket}")
-    private String bucket;
+    private String bucket = "tidy-test-bucket";
 
     @Override
     public String upload(String key, byte[] bytes) {
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(bytes.length);
 
+        log.info("Using bucket: {}", bucket);  // ⬅ 여기 찍기
         amazonS3.putObject(bucket, key, new ByteArrayInputStream(bytes), metadata);
 
         return key;  // DB에는 key만 저장 (URL 아님)


### PR DESCRIPTION
프론트 서버에서 환경변수보다 앞서 읽어오는 버킷 정보가 있어서 tidy 서비스 버킷을 못 읽는 이슈
=> 버킷 읽을때 환경변수를 주입받지 않고 직접 이름을 넣어줌